### PR TITLE
feat: add Markdown support to TerminalGat

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -5,6 +5,7 @@ version = "0.1.0"
 
 [deps]
 IOCapture = "b5f81e59-6552-4d32-b1f0-c071b021bf89"
+Markdown = "d6f4376e-aef5-505a-96c1-9c027394607a"
 TerminalPager = "0c614874-6106-40ed-a7c2-2f1cd0bff883"
 gat_jll = "b88765aa-e0a2-5b02-b897-840ea4e6307e"
 

--- a/src/TerminalGat.jl
+++ b/src/TerminalGat.jl
@@ -1,5 +1,7 @@
 module TerminalGat
 
+using Markdown
+
 using gat_jll: gat_jll
 export gat, gess
 
@@ -15,9 +17,23 @@ function gat(filename::AbstractString)
     nothing
 end
 
+function gat(md::Markdown.MD)
+    str = sprint(show, MIME"text/plain"(), md, context = :color => false)
+    open(pipeline(`$(gat_jll.gat()) --force-color -l julia`), "w", stdout) do f
+        println(f, str)
+    end
+end
+
 function gess(filename::AbstractString)
     c = IOCapture.capture() do
         gat(filename)
+    end
+    c.output |> pager
+end
+
+function gess(md::Markdown.MD)
+    c = IOCapture.capture() do
+        gat(md)
     end
     c.output |> pager
 end


### PR DESCRIPTION
Fortunately, we could support `gat(@doc sin)`

```julia
julia> using TerminalGat; gat((@doc sin))
  sin(x)

  Compute sine of x, where x is in radians.

  See also sind, sinpi, sincos, cis, asin.
  ...
```

<img width="1107" alt="image" src="https://github.com/terasakisatoshi/TerminalGat.jl/assets/16760547/fd3d2959-0ba0-4bbb-afd4-317724f0f35a">
